### PR TITLE
Null token not allowed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -72,4 +72,19 @@ describe('authentic', () => {
       expect(res().output.payload.message).to.contain(badIss)
     )
   })
+
+  describe('with a null token', () => {
+    beforeEach(() =>
+      authentic(null).catch(res)
+    )
+
+    it('booms with a 401', () => {
+      expect(res().isBoom).to.be.true
+      expect(res().output.statusCode).to.equal(401)
+    })
+
+    it('mentions that the token was null', () =>
+      expect(res().output.payload.message).to.contain('null token')
+    )
+  })
 })


### PR DESCRIPTION
![dilbert](https://pbs.twimg.com/media/DEf9oMsXYAAe5UJ.jpg)

I would have expected `jwt.decode(null)` to throw a useful error, but apparently it does not.  So we need to check for `null` tokens and give a descriptive error.