### PR TITLE
Strip Bearer From Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/authentic",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Proper validation of JWT's against JWK's",
   "main": "index.js",
   "repository": "git@github.com:articulate/authentic.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/authentic",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "Proper validation of JWT's against JWK's",
   "main": "index.js",
   "repository": "git@github.com:articulate/authentic.git",

--- a/test/index.js
+++ b/test/index.js
@@ -3,10 +3,12 @@ const jwt        = require('jsonwebtoken')
 const nock       = require('nock')
 const property   = require('prop-factory')
 
-const bad   = require('./fixtures/bad-iss')
-const keys  = require('./fixtures/keys')
-const oidc  = require('./fixtures/oidc')
-const token = require('./fixtures/token')
+const bad                = require('./fixtures/bad-iss')
+const keys               = require('./fixtures/keys')
+const oidc               = require('./fixtures/oidc')
+const token              = require('./fixtures/token')
+const capitalBearerToken = 'Bearer ' + token
+const lowerBearerToken   = 'bearer ' + token
 
 const { issuer } = oidc
 
@@ -36,6 +38,34 @@ describe('authentic', () => {
   describe('with a valid jwt', () => {
     beforeEach(() =>
       authentic(token).then(res)
+    )
+
+    it('validates the jwt against the jwks', () =>
+      expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+    )
+
+    it('caches the jwks client', () =>
+      expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+    )
+  })
+
+  describe('with a valid jwt that starts with Bearer', () => {
+    beforeEach(() =>
+      authentic(capitalBearerToken).then(res)
+    )
+
+    it('validates the jwt against the jwks', () =>
+      expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+    )
+
+    it('caches the jwks client', () =>
+      expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+    )
+  })
+  
+  describe('with a valid jwt that starts with bearer', () => {
+    beforeEach(() =>
+      authentic(lowerBearerToken).then(res)
     )
 
     it('validates the jwt against the jwks', () =>


### PR DESCRIPTION
- Some libraries use the "Bearer" prefix when doing token
  authentication. If we encounter a token with a "Bearer"
  prefix then just strip it off and proceed as normal.