### PR TITLE
Improve Error Handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const jwks     = require('jwks-rsa')
 const jwt      = require('jsonwebtoken')
 
 const {
-  applyTo: thrush, compose, composeP, curryN, merge,
-  mergeDeepRight, partialRight, prop, replace
+  applyTo: thrush, compose, composeP, curryN, isNil, ifElse, merge,
+  mergeDeepRight, partialRight, pathEq, prop, replace, when,
 } = require('ramda')
 
 const { promisify, rename, tapP } = require('@articulate/funky')
@@ -30,11 +30,23 @@ const decode = partialRight(jwt.decode, [{ complete: true }])
 const enforce = token =>
   token || Promise.reject(Boom.unauthorized('null token not allowed'))
 
+const forbidden = err =>
+  Promise.reject(Boom.forbidden(err))
+
+const isExpired =
+  pathEq(['name'], 'TokenExpiredError')
+
 const stripBearer =
   replace(/^Bearer /i, '')
 
+const throwIfNull =
+  when(isNil, () => Promise.reject(new Error('invalid token')))
+
 const unauthorized = err =>
   Promise.reject(Boom.unauthorized(err))
+
+const deny =
+  ifElse(isExpired, forbidden, unauthorized)
 
 const jwksOptsDefaults = { jwks: { cache: true, rateLimit: true } }
 
@@ -65,11 +77,12 @@ const factory = options => {
   const authentic = token =>
     Promise.resolve(token)
       .then(decode)
+      .then(throwIfNull)
       .then(tapP(checkIss))
       .then(getSigningKey)
       .then(chooseKey)
       .then(verify(token))
-      .catch(unauthorized)
+      .catch(deny)
 
   return composeP(authentic, stripBearer, tapP(enforce))
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const {
   mergeDeepRight, partialRight, pathEq, prop, replace, when,
 } = require('ramda')
 
-const { promisify, rename, tapP } = require('@articulate/funky')
+const { promisify, reject, rename, tapP } = require('@articulate/funky')
 
 const wellKnown = '/.well-known/openid-configuration'
 
@@ -29,10 +29,10 @@ const chooseKey = key =>
 const decode = partialRight(jwt.decode, [{ complete: true }])
 
 const enforce = token =>
-  token || Promise.reject(Boom.unauthorized('null token not allowed'))
+  token || reject(Boom.unauthorized('null token not allowed'))
 
 const forbidden = err =>
-  Promise.reject(Boom.forbidden(err))
+  reject(Boom.forbidden(err))
 
 const isIssWhitelistError =
   pathEq(['name'], 'IssWhitelistError')
@@ -41,10 +41,10 @@ const stripBearer =
   replace(/^Bearer /i, '')
 
 const throwIfNull =
-  when(isNil, () => Promise.reject(new Error('invalid token')))
+  when(isNil, () => reject('invalid token'))
 
 const unauthorized = err =>
-  Promise.reject(Boom.unauthorized(err))
+  reject(Boom.unauthorized(err))
 
 const deny =
   ifElse(isIssWhitelistError, forbidden, unauthorized)
@@ -64,7 +64,7 @@ const factory = options => {
 
   const checkIss = token =>
     opts.issWhitelist.indexOf(token.payload.iss) > -1 ||
-    Promise.reject(new IssWhitelistError(`iss '${token.payload.iss}' not in issWhitelist`))
+    reject(new IssWhitelistError(`iss '${token.payload.iss}' not in issWhitelist`))
 
   const getSigningKey = ({ header: { kid }, payload: { iss } }) =>
     clients[iss]

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const jwt      = require('jsonwebtoken')
 const { IssWhitelistError } = require('./lib/errors')
 
 const {
-  applyTo: thrush, compose, composeP, curryN, isNil, ifElse, merge,
-  mergeDeepRight, partialRight, pathEq, prop, replace, when,
+  applyTo: thrush, compose, composeP, curryN, is, isNil, ifElse,
+  merge, mergeDeepRight, partialRight, prop, replace, when
 } = require('ramda')
 
 const { promisify, reject, rename, tapP } = require('@articulate/funky')
@@ -29,13 +29,10 @@ const chooseKey = key =>
 const decode = partialRight(jwt.decode, [{ complete: true }])
 
 const enforce = token =>
-  token || reject(Boom.unauthorized('null token not allowed'))
+  token || unauthorized('null token not allowed')
 
 const forbidden = err =>
   reject(Boom.forbidden(err))
-
-const isIssWhitelistError =
-  pathEq(['name'], 'IssWhitelistError')
 
 const stripBearer =
   replace(/^Bearer /i, '')
@@ -47,7 +44,7 @@ const unauthorized = err =>
   reject(Boom.unauthorized(err))
 
 const deny =
-  ifElse(isIssWhitelistError, forbidden, unauthorized)
+  ifElse(is(IssWhitelistError), forbidden, unauthorized)
 
 const jwksOptsDefaults = { jwks: { cache: true, rateLimit: true } }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,8 @@
+function IssWhitelistError(message, params) {
+  Error.captureStackTrace(this, this.constructor)
+  this.name = 'IssWhitelistError'
+  this.message = message
+  if (params) this.params = params
+}
+IssWhitelistError.prototype = Object.create(Error.prototype)
+module.exports.IssWhitelistError = IssWhitelistError

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,8 +1,7 @@
-function IssWhitelistError(message, params) {
+function IssWhitelistError(message) {
   Error.captureStackTrace(this, this.constructor)
   this.name = 'IssWhitelistError'
   this.message = message
-  if (params) this.params = params
 }
 IssWhitelistError.prototype = Object.create(Error.prototype)
 module.exports.IssWhitelistError = IssWhitelistError

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ const oidc               = require('./fixtures/oidc')
 const token              = require('./fixtures/token')
 const capitalBearerToken = 'Bearer ' + token
 const lowerBearerToken   = 'bearer ' + token
+const malformedBearerToken = 'Bearer' + token.slice(0, 200)
 
 const { issuer } = oidc
 
@@ -148,6 +149,21 @@ describe('authentic', () => {
 
       it('mentions that the token was null', () =>
         expect(res().output.payload.message).to.contain('null token')
+      )
+    })
+
+    describe('with a malformed token', () => {
+      beforeEach(() =>
+        authentic(malformedBearerToken).catch(res)
+      )
+
+      it('booms with a 401', () => {
+        expect(res().isBoom).to.be.true
+        expect(res().output.statusCode).to.equal(401)
+      })
+
+      it('mentions that the token is invalid', () =>
+        expect(res().output.payload.message).to.contain('invalid token')
       )
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -126,9 +126,9 @@ describe('authentic', () => {
         authentic(bad).catch(res)
       )
 
-      it('booms with a 401', () => {
+      it('booms with a 403', () => {
         expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
+        expect(res().output.statusCode).to.equal(403)
       })
 
       it('includes the invalid iss in the error message', () =>


### PR DESCRIPTION
Currently, [`authentic`](https://github.com/articulate/authentic) returns a `401 - Unauthorized` Boom error for *all* errors. This should possibly be changed to match the [RFC2616](https://tools.ietf.org/html/rfc2616#section-10.4.2) spec: 

We should return a `403` response code if the `token.iss_whitelist` is not found in the `issWhitelist` option.

In addition, this PR also improves error handling when `jwt.decode` returns `null` in the case of a malformed token. (would previously throw a `Cannot read property ‘payload’ of null` error)