### PR TITLE
Add Ability to Receive Decoded Token in Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ const handler = req =>
 
 * `verify` Object: options to forward to `jwt.verify` from [`jsonwebtoken`](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 * `issWhitelist` Array: list of trusted OIDC issuers
-* `decodedInErr` Bool: set to `true` to recieve the decoded token as the `data` property of the error when verification fails
+* `claimsInError` Array: list of jwt payload claims to receive as the `data` propery of the error when verification fails.  When a list is not provided a `data` property will not be added to the error.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ const handler = req =>
 
 * `verify` Object: options to forward to `jwt.verify` from [`jsonwebtoken`](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 * `issWhitelist` Array: list of trusted OIDC issuers
+* `decodedInErr` Bool: set to `true` to recieve the decoded token as the `data` property of the error when verification fails

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { IssWhitelistError } = require('./lib/errors')
 
 const {
   applyTo: thrush, compose, composeP, curryN, is, isNil, ifElse,
-  merge, mergeDeepRight, partialRight, prop, replace, when
+  merge, mergeDeepRight, partialRight, pick, prop, replace, when
 } = require('ramda')
 
 const { promisify, reject, rename, tapP } = require('@articulate/funky')
@@ -57,8 +57,8 @@ const factory = options => {
   } = opts
 
   const throwWithData = data => err => {
-    if (opts.decodedInError) { 
-      err.data = data
+    if (Array.isArray(opts.claimsInError)) {
+      err.data = pick(opts.claimsInError, data.payload)
     }
 
     throw err
@@ -80,7 +80,7 @@ const factory = options => {
 
   const jwtVerify = curryN(2, partialRight(promisify(jwt.verify), [ verifyOpts ]))
 
-  const verify = token => decoded => 
+  const verify = token => decoded =>
     getSigningKey(decoded)
       .then(chooseKey)
       .then(jwtVerify(token))

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,7 @@ describe('authentic', () => {
 
   describe('setup with minimal valid configuration options', () => {
     const authentic = require('..')({
-      issWhitelist: [ issuer ],
+      issWhitelist: [ issuer ]
     })
 
     describe('with an expired jwt', () => {
@@ -45,6 +45,26 @@ describe('authentic', () => {
       it('booms with a 401', () => {
         expect(res().isBoom).to.be.true
         expect(res().output.statusCode).to.equal(401)
+        expect(res().data).to.be.null
+      })
+    })
+  })
+  
+  describe('setup with decodedInError set to true', () => {
+    const authentic = require('..')({
+      issWhitelist: [ issuer ],
+      decodedInError: true
+    })
+
+    describe('with an expired jwt', () => {
+      beforeEach(() =>
+        authentic(token).catch(res)
+      )
+
+      it('booms with a 401', () => {
+        expect(res().isBoom).to.be.true
+        expect(res().output.statusCode).to.equal(401)
+        expect(res().data.payload.sub).to.equal('00udjyjssbt2S1QVr0h7')
       })
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -49,11 +49,11 @@ describe('authentic', () => {
       })
     })
   })
-  
-  describe('setup with decodedInError set to true', () => {
+
+  describe('setup with invalid claimsInError value', () => {
     const authentic = require('..')({
       issWhitelist: [ issuer ],
-      decodedInError: true
+      claimsInError: 'sub'
     })
 
     describe('with an expired jwt', () => {
@@ -64,7 +64,28 @@ describe('authentic', () => {
       it('booms with a 401', () => {
         expect(res().isBoom).to.be.true
         expect(res().output.statusCode).to.equal(401)
-        expect(res().data.payload.sub).to.equal('00udjyjssbt2S1QVr0h7')
+        expect(res().data).to.be.null
+      })
+    })
+  })
+
+  describe('setup with claimsInError set to a list of claim(s)', () => {
+    const authentic = require('..')({
+      issWhitelist: [ issuer ],
+      claimsInError: [ 'sub', 'iss' ]
+    })
+
+    describe('with an expired jwt', () => {
+      beforeEach(() =>
+        authentic(token).catch(res)
+      )
+
+      it('booms with a 401', () => {
+        expect(res().isBoom).to.be.true
+        expect(res().output.statusCode).to.equal(401)
+        expect(res().data).to.have.keys(['sub', 'iss'])
+        expect(res().data.sub).to.equal('00udjyjssbt2S1QVr0h7')
+        expect(res().data.iss).to.equal('https://authentic.articulate.com/')
       })
     })
   })


### PR DESCRIPTION
- Add an option to receive the decoded token as part of verification
errors

For certain scenarios, we're interested in looking at properties on the decoded token as part of our error logging. This makes it so that we don't have to re-decode the token ourselves.