### PR TITLE
Slim Down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'
 before_install:
   - npm install -g yarn@1.3.2
 install:

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const jwksOptsDefaults = { jwks: { cache: true, rateLimit: true } }
 
 const factory = options => {
   const clients = {}
-  
+
   const opts = Object.assign({}, jwksOptsDefaults, options, {
     jwks: Object.assign({}, jwksOptsDefaults.jwks, options.jwks)
   })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const axios                 = require('axios')
-const deepmerge             = require('deepmerge')
+const merge                 = require('merge')
 const Boom                  = require('boom')
 const jwks                  = require('jwks-rsa')
 const jwt                   = require('jsonwebtoken')
@@ -51,7 +51,7 @@ const jwksOptsDefaults = { jwks: { cache: true, rateLimit: true } }
 
 const factory = options => {
   const clients = {}
-  const opts = deepmerge(jwksOptsDefaults, options)
+  const opts = merge(jwksOptsDefaults, options)
   const {
     verify: verifyOpts = {},
     jwks: jwksOpts

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const axios                 = require('axios')
-const merge                 = require('merge')
+const merge                 = require('@ianwalter/merge')
 const Boom                  = require('boom')
 const jwks                  = require('jwks-rsa')
 const jwt                   = require('jsonwebtoken')

--- a/index.js
+++ b/index.js
@@ -101,8 +101,7 @@ const factory = options => {
 
   return token =>
     Promise.resolve(token)
-      .then(enforce)
-      .then(() => token)
+      .then(tapP(enforce))
       .then(stripBearer)
       .then(authentic)
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const axios                 = require('axios')
-const merge                 = require('@ianwalter/merge')
 const Boom                  = require('boom')
 const jwks                  = require('jwks-rsa')
 const jwt                   = require('jsonwebtoken')
@@ -51,7 +50,11 @@ const jwksOptsDefaults = { jwks: { cache: true, rateLimit: true } }
 
 const factory = options => {
   const clients = {}
-  const opts = merge(jwksOptsDefaults, options)
+  
+  const opts = Object.assign({}, jwksOptsDefaults, options, {
+    jwks: Object.assign({}, jwksOptsDefaults.jwks, options.jwks)
+  })
+
   const {
     verify: verifyOpts = {},
     jwks: jwksOpts

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+const axios    = require('axios')
 const Boom     = require('boom')
-const gimme    = require('@articulate/gimme')
 const jwks     = require('jwks-rsa')
 const jwt      = require('jsonwebtoken')
 const { IssWhitelistError } = require('./lib/errors')
@@ -17,8 +17,8 @@ const bindFunction = client =>
   promisify(client.getSigningKey, client)
 
 const buildClient = (jwksOpts, url) =>
-  gimme({ url })
-    .then(prop('body'))
+  axios.get(url)
+    .then(prop('data'))
     .then(rename('jwks_uri', 'jwksUri'))
     .then(compose(jwks, merge(jwksOpts)))
     .then(bindFunction)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,11 @@
+exports.rename = (prevKey, nextKey) => obj => {
+  const next = {}
+  for (const key in obj) {
+    if (key === prevKey) next[nextKey] = obj[prevKey]
+    else next[key] === obj[key]
+  }
+  return next
+}
+
+exports.tapP = fn => val =>
+  Promise.resolve(val).then(fn).then(() => val)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:coverage": "nyc yarn test"
   },
   "dependencies": {
-    "@ianwalter/merge": "^9.0.1",
     "axios": "^0.20.0",
     "boom": "7.3.x",
     "jsonwebtoken": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@articulate/gimme": "^1.0.0",
     "boom": "7.3.x",
     "jsonwebtoken": "^8.1.1",
-    "jwks-rsa": "^1.2.1",
+    "jwks-rsa": "^1.9.0",
     "ramda": "^0.25.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@articulate/funky": "^1.2.0",
-    "@articulate/gimme": "^1.0.0",
+    "axios": "^0.20.0",
     "boom": "7.3.x",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "axios": "^0.20.0",
     "boom": "7.3.x",
-    "deepmerge": "^4.2.2",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.9.0",
-    "lodash.pick": "^4.4.0"
+    "lodash.pick": "^4.4.0",
+    "merge": "^1.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test:coverage": "nyc yarn test"
   },
   "dependencies": {
+    "@ianwalter/merge": "^9.0.1",
     "axios": "^0.20.0",
     "boom": "7.3.x",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.9.0",
-    "lodash.pick": "^4.4.0",
-    "merge": "^1.2.1"
+    "lodash.pick": "^4.4.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   "dependencies": {
     "axios": "^0.20.0",
     "boom": "7.3.x",
+    "deepmerge": "^4.2.2",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.9.0",
-    "ramda": "^0.25.0"
+    "lodash.pick": "^4.4.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:coverage": "nyc yarn test"
   },
   "dependencies": {
-    "@articulate/funky": "^1.2.0",
     "axios": "^0.20.0",
     "boom": "7.3.x",
     "jsonwebtoken": "^8.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -20,192 +20,362 @@ const wellKnown = '/.well-known/openid-configuration'
 
 describe('authentic', () => {
   const res = property()
-
-  beforeEach(() => {
-    nock(issuer).get(wellKnown).once().reply(200, oidc)
-    nock(issuer).get('/v1/keys').once().reply(200, keys)
-  })
-
   nock.disableNetConnect()
 
-  afterEach(() =>
-    nock.cleanAll()
-  )
-
-  describe('setup with minimal valid configuration options', () => {
-    const authentic = require('..')({
-      issWhitelist: [ issuer ]
+  context('valid well-known configuration', () => {
+    beforeEach(() => {
+      nock(issuer).get(wellKnown).once().reply(200, oidc)
+      nock(issuer).get('/v1/keys').once().reply(200, keys)
     })
 
-    describe('with an expired jwt', () => {
-      beforeEach(() =>
-        authentic(token).catch(res)
-      )
+    afterEach(() =>
+      nock.cleanAll()
+    )
 
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
-        expect(res().data).to.be.null
+    describe('setup with minimal valid configuration options', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ]
       })
-    })
-  })
 
-  describe('setup with invalid claimsInError value', () => {
-    const authentic = require('..')({
-      issWhitelist: [ issuer ],
-      claimsInError: 'sub'
-    })
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
 
-    describe('with an expired jwt', () => {
-      beforeEach(() =>
-        authentic(token).catch(res)
-      )
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
-        expect(res().data).to.be.null
-      })
-    })
-  })
-
-  describe('setup with claimsInError set to a list of claim(s)', () => {
-    const authentic = require('..')({
-      issWhitelist: [ issuer ],
-      claimsInError: [ 'sub', 'iss' ]
-    })
-
-    describe('with an expired jwt', () => {
-      beforeEach(() =>
-        authentic(token).catch(res)
-      )
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
-        expect(res().data).to.have.keys(['sub', 'iss'])
-        expect(res().data.sub).to.equal('00udjyjssbt2S1QVr0h7')
-        expect(res().data.iss).to.equal('https://authentic.articulate.com/')
-      })
-    })
-  })
-
-  describe('setup with valid configuration options', () => {
-    const authentic = require('..')({
-      verify: { ignoreExpiration: true },
-      issWhitelist: [ issuer ],
-    })
-
-    describe('with a valid jwt', () => {
-      beforeEach(() =>
-        authentic(token).then(res)
-      )
-
-      it('validates the jwt against the jwks', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-
-      it('caches the jwks client', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-    })
-
-    describe('with a valid jwt that starts with Bearer', () => {
-      beforeEach(() =>
-        authentic(capitalBearerToken).then(res)
-      )
-
-      it('validates the jwt against the jwks', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-
-      it('caches the jwks client', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-    })
-
-    describe('with a valid jwt that starts with bearer', () => {
-      beforeEach(() =>
-        authentic(lowerBearerToken).then(res)
-      )
-
-      it('validates the jwt against the jwks', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-
-      it('caches the jwks client', () =>
-        expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
-      )
-    })
-
-    describe('with an invalid jwt', () => {
-      beforeEach(() =>
-        authentic('invalid').catch(res)
-      )
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
-      })
-    })
-
-    describe('with an expired jwt', () => {
-      beforeEach(() => {
-        const auth = require('..')({
-          issWhitelist: [ issuer ],
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
         })
-        auth(token).catch(res)
-      })
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
       })
     })
 
-    describe('with an invalid iss', () => {
-      beforeEach(() =>
-        authentic(bad).catch(res)
-      )
-
-      it('booms with a 403', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(403)
+    describe('setup with invalid claimsInError value', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ],
+        claimsInError: 'sub'
       })
 
-      it('includes the invalid iss in the error message', () =>
-        expect(res().output.payload.message).to.contain(badIss)
-      )
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
     })
 
-    describe('with a null token', () => {
-      beforeEach(() =>
-        authentic(null).catch(res)
-      )
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
+    describe('setup with claimsInError set to a list of claim(s)', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ],
+        claimsInError: [ 'sub', 'iss' ]
       })
 
-      it('mentions that the token was null', () =>
-        expect(res().output.payload.message).to.contain('null token')
-      )
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
     })
 
-    describe('with a malformed token', () => {
-      beforeEach(() =>
-        authentic(malformedBearerToken).catch(res)
-      )
-
-      it('booms with a 401', () => {
-        expect(res().isBoom).to.be.true
-        expect(res().output.statusCode).to.equal(401)
+    describe('setup with valid configuration options', () => {
+      const authentic = require('..')({
+        verify: { ignoreExpiration: true },
+        issWhitelist: [ issuer ],
       })
 
-      it('mentions that the token is invalid', () =>
-        expect(res().output.payload.message).to.contain('invalid token')
-      )
+      describe('with a valid jwt', () => {
+        beforeEach(() =>
+          authentic(token).then(res)
+        )
+
+        it('validates the jwt against the jwks', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+
+        it('caches the jwks client', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+      })
+
+      describe('with a valid jwt that starts with Bearer', () => {
+        beforeEach(() =>
+          authentic(capitalBearerToken).then(res)
+        )
+
+        it('validates the jwt against the jwks', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+
+        it('caches the jwks client', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+      })
+
+      describe('with a valid jwt that starts with bearer', () => {
+        beforeEach(() =>
+          authentic(lowerBearerToken).then(res)
+        )
+
+        it('validates the jwt against the jwks', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+
+        it('caches the jwks client', () =>
+          expect(res().sub).to.equal('00udjyjssbt2S1QVr0h7')
+        )
+      })
+
+      describe('with an invalid jwt', () => {
+        beforeEach(() =>
+          authentic('invalid').catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with an expired jwt', () => {
+        beforeEach(() => {
+          const auth = require('..')({
+            issWhitelist: [ issuer ],
+          })
+          auth(token).catch(res)
+        })
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with an invalid iss', () => {
+        beforeEach(() =>
+          authentic(bad).catch(res)
+        )
+
+        it('booms with a 403', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(403)
+        })
+
+        it('includes the invalid iss in the error message', () =>
+          expect(res().output.payload.message).to.contain(badIss)
+        )
+      })
+
+      describe('with a null token', () => {
+        beforeEach(() =>
+          authentic(null).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('mentions that the token was null', () =>
+          expect(res().output.payload.message).to.contain('null token')
+        )
+      })
+
+      describe('with a malformed token', () => {
+        beforeEach(() =>
+          authentic(malformedBearerToken).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('mentions that the token is invalid', () =>
+          expect(res().output.payload.message).to.contain('invalid token')
+        )
+      })
+    })
+  })
+
+  context('invalid well-known configuration', () => {
+    beforeEach(() => {
+      nock(issuer).get(wellKnown).once().reply(404)
+      nock(issuer).get('/v1/keys').once().reply(200, keys)
+    })
+
+    afterEach(() =>
+      nock.cleanAll()
+    )
+
+    describe('setup with minimal valid configuration options', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ]
+      })
+
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+    })
+
+    describe('setup with invalid claimsInError value', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ],
+        claimsInError: 'sub'
+      })
+
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+    })
+
+    describe('setup with claimsInError set to a list of claim(s)', () => {
+      const authentic = require('..')({
+        issWhitelist: [ issuer ],
+        claimsInError: [ 'sub', 'iss' ]
+      })
+
+      describe('with an expired jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+    })
+
+    describe('setup with valid configuration options', () => {
+      const authentic = require('..')({
+        verify: { ignoreExpiration: true },
+        issWhitelist: [ issuer ],
+      })
+
+      describe('with a valid jwt', () => {
+        beforeEach(() =>
+          authentic(token).catch(res)
+        )
+
+        it('booms 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with a valid jwt that starts with Bearer', () => {
+        beforeEach(() =>
+          authentic(capitalBearerToken).catch(res)
+        )
+
+        it('booms 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with a valid jwt that starts with bearer', () => {
+        beforeEach(() =>
+          authentic(lowerBearerToken).catch(res)
+        )
+
+        it('booms 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with an invalid jwt', () => {
+        beforeEach(() =>
+          authentic('invalid').catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with an expired jwt', () => {
+        beforeEach(() => {
+          const auth = require('..')({
+            issWhitelist: [ issuer ],
+          })
+          auth(token).catch(res)
+        })
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+      })
+
+      describe('with an invalid iss', () => {
+        beforeEach(() =>
+          authentic(bad).catch(res)
+        )
+
+        it('booms with a 403', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(403)
+        })
+
+        it('includes the invalid iss in the error message', () =>
+          expect(res().output.payload.message).to.contain(badIss)
+        )
+      })
+
+      describe('with a null token', () => {
+        beforeEach(() =>
+          authentic(null).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('mentions that the token was null', () =>
+          expect(res().output.payload.message).to.contain('null token')
+        )
+      })
+
+      describe('with a malformed token', () => {
+        beforeEach(() =>
+          authentic(malformedBearerToken).catch(res)
+        )
+
+        it('booms with a 401', () => {
+          expect(res().isBoom).to.be.true
+          expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('mentions that the token is invalid', () =>
+          expect(res().output.payload.message).to.contain('invalid token')
+        )
+      })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,11 +90,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@ianwalter/merge@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@ianwalter/merge/-/merge-9.0.1.tgz#bbbf15e1daec5fef7e28633d9e8060a62018a72d"
-  integrity sha512-Wu7eAZEsfuW0FJsVsdsNaWAtlY/6Viy74HQpZ8A81KutjhNO5cyPRkiBGletuX9kDUTOdSwWJokPnu/o4yE3KA==
-
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
@@ -1862,6 +1867,11 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
 lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -2470,11 +2480,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 read-pkg-up@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,33 +2,12 @@
 # yarn lockfile v1
 
 
-"@articulate/funky@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-0.0.2.tgz#69a522b947a602f811490ac85fd37338da1e7406"
-  integrity sha512-rdoDKZiTl8kmiTyiGUkwx8/OOF+8RDtA5tyas7X5SkH4qvKFFNq5G/CnQioFvtJ+qar8lYVSYGslITV/awcTwQ==
-  dependencies:
-    joi "^10.6.0"
-    ramda "^0.24.1"
-
 "@articulate/funky@^1.2.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-1.6.0.tgz#1259f7fb8689f347d6f4e5180e2a1f62aa32ff58"
   integrity sha512-m/gf6dWEPvqBi2MU0W1L1WsNG/b/3qSpuQArCtFO8HNsom6ZQ8RoFHjaBOM8ZDRqp0raujGF1li6FQ2KGQYfYg==
   dependencies:
     ramda "^0.25.0"
-
-"@articulate/gimme@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@articulate/gimme/-/gimme-1.0.2.tgz#7cbda498eb0487bae28f2519fc22f7f5f3033044"
-  integrity sha512-mG40STy+IEa6ZqZUQvWUA/SFtKOMMGfHD1TOmtMZDES/RDJlzhCF7j2G44QwqOTSJ4xh2iWv45Ao2VxjlnHn9A==
-  dependencies:
-    "@articulate/funky" "^0.0.2"
-    boom "^5.2.0"
-    joi "^10.6.0"
-    media-typer "^0.3.0"
-    qs "^6.5.0"
-    ramda "^0.24.1"
-    raw-body "^2.2.0"
 
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
@@ -355,6 +334,13 @@ axios@^0.19.2:
   dependencies:
     follow-redirects "1.5.10"
 
+axios@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
+  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -386,13 +372,6 @@ boom@7.3.x:
   integrity sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==
   dependencies:
     hoek "6.x.x"
-
-boom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
-  dependencies:
-    hoek "4.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -427,11 +406,6 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
-
-bytes@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
-  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -737,11 +711,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -1102,6 +1071,11 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1311,11 +1285,6 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
-
 hoek@6.x.x:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
@@ -1333,16 +1302,6 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
-http-errors@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1351,13 +1310,6 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-iconv-lite@0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -1392,7 +1344,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3:
+inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -1586,11 +1538,6 @@ isarray@1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isemail@2.x.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
-  integrity sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1664,21 +1611,6 @@ istanbul-reports@^2.1.1:
   integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
   dependencies:
     handlebars "^4.1.0"
-
-items@2.x.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/items/-/items-2.1.2.tgz#0849354595805d586dac98e7e6e85556ea838558"
-  integrity sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==
-
-joi@^10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
-  integrity sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==
-  dependencies:
-    hoek "4.x.x"
-    isemail "2.x.x"
-    items "2.x.x"
-    topo "2.x.x"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2011,11 +1943,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-media-typer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 mem@^4.0.0:
   version "4.1.0"
@@ -2541,7 +2468,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.5.0, qs@^6.5.1:
+qs@^6.5.1:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
   integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
@@ -2551,25 +2478,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
-  integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
-
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
   integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
-
-raw-body@^2.2.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
-  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
-  dependencies:
-    bytes "3.0.0"
-    http-errors "1.6.3"
-    iconv-lite "0.4.23"
-    unpipe "1.0.0"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -2760,11 +2672,6 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setprototypeof@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
-  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -2920,11 +2827,6 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
-
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -3075,13 +2977,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topo@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
-  integrity sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=
-  dependencies:
-    hoek "4.x.x"
-
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -3141,11 +3036,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
-
-unpipe@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 unset-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,10 +133,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-jwt@0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.34.tgz#fdbee4c6af5c0a246ef2a933f5519973c7717f02"
-  integrity sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=
+"@types/express-jwt@0.0.42":
+  version "0.0.42"
+  resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.42.tgz#4f04e1fadf9d18725950dc041808a4a4adf7f5ae"
+  integrity sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==
   dependencies:
     "@types/express" "*"
     "@types/express-unless" "*"
@@ -347,6 +347,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -641,6 +648,13 @@ debug@3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1080,6 +1094,13 @@ flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -1731,6 +1752,22 @@ jsonwebtoken@^8.1.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -1750,17 +1787,27 @@ jwa@^1.2.0:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jwks-rsa@^1.2.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.4.0.tgz#269cd2466afe7ab377fec55516f5e3019f22f0e5"
-  integrity sha512-6aUc+oTuqsLwIarfq3A0FqoD5LFSgveW5JO1uX2s0J8TJuOEcDc4NIMZAmVHO8tMHDw7CwOPzXF/9QhfOpOElA==
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
   dependencies:
-    "@types/express-jwt" "0.0.34"
-    debug "^2.2.0"
-    limiter "^1.1.0"
-    lru-memoizer "^1.6.0"
-    ms "^2.0.0"
-    request "^2.73.0"
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwks-rsa@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.9.0.tgz#efa0cd550c13b70397e27cd8764bd53c45a1ad91"
+  integrity sha512-UPCfQQg0s2kF2Ju6UFJrQH73f7MaVN/hKBnYBYOp+X9KN4y6TLChhLtaXS5nRKbZqshwVdrZ9OY63m/Q9CLqcg==
+  dependencies:
+    "@types/express-jwt" "0.0.42"
+    axios "^0.19.2"
+    debug "^4.1.0"
+    jsonwebtoken "^8.5.1"
+    limiter "^1.1.5"
+    lru-memoizer "^2.1.2"
+    ms "^2.1.2"
 
 jws@^3.2.1:
   version "3.2.1"
@@ -1768,6 +1815,14 @@ jws@^3.2.1:
   integrity sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==
   dependencies:
     jwa "^1.2.0"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
@@ -1814,10 +1869,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-limiter@^1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.4.tgz#87c9c3972d389fdb0ba67a45aadbc5d2f8413bc1"
-  integrity sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg==
+limiter@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
+  integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -1837,10 +1892,10 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lock@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
-  integrity sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -1882,7 +1937,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -1915,15 +1970,13 @@ lru-cache@~4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-memoizer@^1.6.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.12.0.tgz#efe65706cc8a9cc653f80f0d5a6ea38ad950e352"
-  integrity sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=
+lru-memoizer@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-2.1.2.tgz#5c6b43659c78ad0e9e65bf81a9e5ef1ee109a2dd"
+  integrity sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==
   dependencies:
-    lock "~0.1.2"
-    lodash "^4.17.4"
+    lodash.clonedeep "^4.5.0"
     lru-cache "~4.0.0"
-    very-fast-args "^1.1.0"
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -2087,10 +2140,15 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.1, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -2560,7 +2618,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request@^2.73.0, request@^2.86.0:
+request@^2.86.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -3135,11 +3193,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-very-fast-args@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/very-fast-args/-/very-fast-args-1.1.0.tgz#e16d1d1faf8a6e596a246421fd90a77963d0b396"
-  integrity sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y=
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@articulate/funky@^1.2.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-1.6.0.tgz#1259f7fb8689f347d6f4e5180e2a1f62aa32ff58"
-  integrity sha512-m/gf6dWEPvqBi2MU0W1L1WsNG/b/3qSpuQArCtFO8HNsom6ZQ8RoFHjaBOM8ZDRqp0raujGF1li6FQ2KGQYfYg==
-  dependencies:
-    ramda "^0.25.0"
-
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@ianwalter/merge@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@ianwalter/merge/-/merge-9.0.1.tgz#bbbf15e1daec5fef7e28633d9e8060a62018a72d"
+  integrity sha512-Wu7eAZEsfuW0FJsVsdsNaWAtlY/6Viy74HQpZ8A81KutjhNO5cyPRkiBGletuX9kDUTOdSwWJokPnu/o4yE3KA==
+
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
@@ -1957,11 +1962,6 @@ merge-source-map@^1.1.0:
   integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
   dependencies:
     source-map "^0.6.1"
-
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 micromatch@^3.0.4:
   version "3.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,11 +664,6 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
@@ -1962,6 +1957,11 @@ merge-source-map@^1.1.0:
   integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
   dependencies:
     source-map "^0.6.1"
+
+merge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 micromatch@^3.0.4:
   version "3.1.10"


### PR DESCRIPTION
I'd like to use authentic in a lambda@edge. Unfortunately, there are strict size limits, & authentic would need to be slimmed down significantly. This is my proposal:

* Bump to latest `jwks-rsa`, which drops `request` in favor of `axios` & drops `lodash`
* Drop `gimme` in favor of `axios`, since `jwks-rsa` is using it already
* Drop `funky`
* Drop `ramda`

Misc
* Add node 12 travis while dropping node 6