### PR TITLE
Check for expired token before verifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,12 +38,6 @@ const stripBearer = str =>
 const throwIfNull = val =>
   val == null ? Promise.reject('invalid token') : val
 
-const throwIfExpired = ({ ignoreExpiration }) => exp => {
-  if (!ignoreExpiration && exp && exp > (Date.now() / 1000)) {
-    Promise.reject(new TokenExpiredError('JWT expired', new Date(exp * 1000)))
-  }
-}
-
 const unauthorized = err =>
   Promise.reject(Boom.unauthorized(err))
 
@@ -82,11 +76,13 @@ const factory = options => {
     opts.issWhitelist.indexOf(token.payload.iss) > -1 ||
     Promise.reject(new IssWhitelistError(`iss '${token.payload.iss}' not in issWhitelist`))
 
-  const checkExp = ({ payload }) =>
-    Promise.resolve(payload)
-      .then(res => res.exp)
-      .then(throwIfExpired(verifyOpts))
-      .catch(throwWithData({ payload }))
+  const checkExp = ({ ignoreExpiration }) => ({ payload: { exp } }) => {
+    if (ignoreExpiration) return
+
+    if (exp && exp > (Date.now() / 1000)) {
+      Promise.reject(new TokenExpiredError('JWT expired', new Date(exp * 999)))
+    }
+  }
 
   const getSigningKey = ({ header: { kid }, payload: { iss } }) =>
     clients[iss]
@@ -109,7 +105,7 @@ const factory = options => {
       .then(decode)
       .then(throwIfNull)
       .then(tapP(checkIss))
-      .then(tapP(checkExp))
+      .then(tapP(checkExp(verifyOpts)))
       .then(verify(token))
       .catch(deny)
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const factory = options => {
   const checkExp = ({ ignoreExpiration }) => ({ payload: { exp } }) => {
     if (ignoreExpiration) return
 
-    if (exp && exp > (Date.now() / 1000)) {
+    if (exp && exp <= (Date.now() / 1000)) {
       throw new TokenExpiredError('JWT expired', new Date(exp * 999))
     }
   }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const factory = options => {
     if (ignoreExpiration) return
 
     if (exp && exp > (Date.now() / 1000)) {
-      Promise.reject(new TokenExpiredError('JWT expired', new Date(exp * 999)))
+      throw new TokenExpiredError('JWT expired', new Date(exp * 999))
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "6.0.x",
     "nock": "10.x.x",
     "nyc": "13.x.x",
-    "prop-factory": "^1.0.0"
+    "prop-factory": "^1.0.0",
+    "sinon": "^9.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,11 @@ describe('authentic', () => {
           expect(res().isBoom).to.be.true
           expect(res().output.statusCode).to.equal(401)
         })
+
+        it('throws with TokenExpiredError', () => {
+          expect(res().name).to.equal('TokenExpiredError')
+          expect(res().message).to.equal('jwt expired')
+        })
       })
     })
 
@@ -64,6 +69,11 @@ describe('authentic', () => {
         it('booms with a 401', () => {
           expect(res().isBoom).to.be.true
           expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('throws with TokenExpiredError', () => {
+          expect(res().name).to.equal('TokenExpiredError')
+          expect(res().message).to.equal('jwt expired')
         })
       })
     })
@@ -83,6 +93,11 @@ describe('authentic', () => {
           expect(res().isBoom).to.be.true
           expect(res().output.statusCode).to.equal(401)
         })
+      })
+
+      it('throws with TokenExpiredError', () => {
+        expect(res().name).to.equal('TokenExpiredError')
+        expect(res().message).to.equal('jwt expired')
       })
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ describe('authentic', () => {
 
         it('throws with TokenExpiredError', () => {
           expect(res().name).to.equal('TokenExpiredError')
-          expect(res().message).to.equal('jwt expired')
+          expect(res().message).to.equal('JWT expired')
         })
       })
     })
@@ -73,7 +73,7 @@ describe('authentic', () => {
 
         it('throws with TokenExpiredError', () => {
           expect(res().name).to.equal('TokenExpiredError')
-          expect(res().message).to.equal('jwt expired')
+          expect(res().message).to.equal('JWT expired')
         })
       })
     })
@@ -97,7 +97,7 @@ describe('authentic', () => {
 
       it('throws with TokenExpiredError', () => {
         expect(res().name).to.equal('TokenExpiredError')
-        expect(res().message).to.equal('jwt expired')
+        expect(res().message).to.equal('JWT expired')
       })
     })
 
@@ -182,7 +182,7 @@ describe('authentic', () => {
 
         it('throws with TokenExpiredError', () => {
           expect(res().name).to.equal('TokenExpiredError')
-          expect(res().message).to.equal('jwt expired')
+          expect(res().message).to.equal('JWT expired')
         })
       })
 

--- a/test/index.js
+++ b/test/index.js
@@ -164,6 +164,11 @@ describe('authentic', () => {
         it('never verifies token', () => {
           expect(verify.called).to.be.false
         })
+
+        it('throws with TokenExpiredError', () => {
+          expect(res().name).to.equal('TokenExpiredError')
+          expect(res().message).to.equal('jwt expired')
+        })
       })
 
       describe('with an invalid iss', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 const jwt        = require('jsonwebtoken')
 const nock       = require('nock')
 const property   = require('prop-factory')
+const sinon      = require('sinon')
 
 const bad                = require('./fixtures/bad-iss')
 const keys               = require('./fixtures/keys')
@@ -145,9 +146,12 @@ describe('authentic', () => {
       })
 
       describe('with an expired jwt', () => {
+        const verify = sinon.stub()
+
         beforeEach(() => {
           const auth = require('..')({
             issWhitelist: [ issuer ],
+            jwtAdapter: { verify }
           })
           auth(token).catch(res)
         })
@@ -155,6 +159,10 @@ describe('authentic', () => {
         it('booms with a 401', () => {
           expect(res().isBoom).to.be.true
           expect(res().output.statusCode).to.equal(401)
+        })
+
+        it('never verifies token', () => {
+          expect(verify.called).to.be.false
         })
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,42 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.2.0.tgz#fcff83ab86f83b5498f4a967869c079408d9b5eb"
+  integrity sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
@@ -715,6 +751,11 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1223,6 +1264,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
@@ -1526,6 +1572,11 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1703,6 +1754,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
+
 jwa@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.3.0.tgz#061a7c3bb8ab2b3434bb2f432005a8bb7fca0efa"
@@ -1826,6 +1882,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.includes@^4.3.0:
   version "4.3.0"
@@ -2107,6 +2168,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 nock@10.x.x:
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
@@ -2378,6 +2450,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -2682,6 +2761,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+sinon@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.0.tgz#1d333967e30023609f7347351ebc0dc964c0f3c9"
+  integrity sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.2.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
@@ -2903,6 +2995,13 @@ supports-color@^6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 table@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
@@ -3007,7 +3106,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
@darrenwhite24 original created this changeset as a part of this PR: https://github.com/articulate/authentic/pull/20

It has since become stale in relation to other changes and I found it easier to re-implement.  This is all credit to @darrenwhite24 

## Description

This PR adds an expiration check before the token is verified. For context, we've recently received a lot of Okta signing key errors and if the token has also expired, the expiration check should quiet some of those errors and trigger an attempt to refresh the token.