### PR TITLE
Export all TS interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 declare module '@articulate/authentic' {
-  function Authentic(opts: Authentic.AuthenticOpts): Authentic.Validator
 
   namespace Authentic {
     interface JWT {
@@ -44,6 +43,8 @@ declare module '@articulate/authentic' {
       (token: string): Promise<Authentic.JWT>
     }
   }
+
+  function Authentic(opts: Authentic.AuthenticOpts): Authentic.Validator
 
   export = Authentic
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,5 @@
 declare module '@articulate/authentic' {
-  interface VerifyOpts {
-    algorithms?: string[]
-    audience?: string | RegExp | Array<string | RegExp>
-    clockTimestamp?: number
-    clockTolerance?: number
-    issuer?: string | string[]
-    ignoreExpiration?: boolean
-    ignoreNotBefore?: boolean
-    jwtid?: string
-    subject?: string
-    maxAge?: string
-  }
-
-  interface JWKSOpts {
-    cache?: boolean
-    rateLimit?: boolean
-  }
-
-  interface AuthenticOpts {
-    issWhitelist: string[]
-    jwks?: JWKSOpts
-    verify?: VerifyOpts
-  }
-
-  interface Validator {
-    (token: string): Promise<Authentic.JWT>
-  }
-
-  function Authentic(opts: AuthenticOpts): Validator
+  function Authentic(opts: Authentic.AuthenticOpts): Authentic.Validator
 
   namespace Authentic {
     interface JWT {
@@ -42,6 +14,34 @@ declare module '@articulate/authentic' {
       sub: string
       uid?: number
       [key: string]: any
+    }
+
+    interface VerifyOpts {
+      algorithms?: string[]
+      audience?: string | RegExp | Array<string | RegExp>
+      clockTimestamp?: number
+      clockTolerance?: number
+      issuer?: string | string[]
+      ignoreExpiration?: boolean
+      ignoreNotBefore?: boolean
+      jwtid?: string
+      subject?: string
+      maxAge?: string
+    }
+
+    interface JWKSOpts {
+      cache?: boolean
+      rateLimit?: boolean
+    }
+
+    interface AuthenticOpts {
+      issWhitelist: string[]
+      jwks?: JWKSOpts
+      verify?: VerifyOpts
+    }
+
+    interface Validator {
+      (token: string): Promise<Authentic.JWT>
     }
   }
 


### PR DESCRIPTION
**issue:** https://github.com/articulate/platform-identity/issues/491

Export all the package interfaces rather than only `JWT`, this way other packages or projects can reuse these interfaces, instead of rewriting them.

I didn't remove the namespace to export these interfaces, otherwise, the following import wouldn't work anymore:

```js
import * as Authentic from "@articulate/authentic"

Authentic() // function
Authentic.JWT // interface
```