### PR TITLE
Add `claimsInError` prop in TS definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ const handler = req =>
 
 * `verify` Object: options to forward to `jwt.verify` from [`jsonwebtoken`](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)
 * `issWhitelist` Array: list of trusted OIDC issuers
-* `claimsInError` Array: list of jwt payload claims to receive as the `data` propery of the error when verification fails.  When a list is not provided a `data` property will not be added to the error.
+* `claimsInError` Array: list of jwt payload claims to receive as the `data` property of the error when verification fails.  When a list is not provided a `data` property will not be added to the error.

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare module '@articulate/authentic' {
     }
 
     interface AuthenticOpts {
+      claimsInError?: string[]
       issWhitelist: string[]
       jwks?: JWKSOpts
       verify?: VerifyOpts


### PR DESCRIPTION
**issue**: https://github.com/articulate/platform-identity/issues/491

### What is this and what is this for?

Added the missing `claimsInError` [prop](https://github.com/articulate/authentic#options) in the TypeScript definition.