### PR TITLE
Use `request` instead of `get` for HTTP requests

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -5,7 +5,8 @@ const getRequest = (url, timeout = 30 * 1000) =>
   new Promise((resolve, reject) => {
     const urlObject = new URL(url)
     const httpRequestLib = urlObject.protocol === 'https:' ? https : http
-    const httpRequest = httpRequestLib.get(urlObject, { timeout }, res => {
+    const httpOptions = { method: 'GET', timeout }
+    const httpRequest = httpRequestLib.request(urlObject, httpOptions, res => {
       const rawData = []
 
       res.setEncoding('utf8')


### PR DESCRIPTION
Some libraries like [agent-base](https://www.npmjs.com/package/agent-base/v/4.3.0?activeTab=code) and [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent/v/2.1.0?activeTab=code), which were used by old versions of Puppeteer, pollute the global `https` object and overwrite the global `https.get` method to add some custom logic to support old node versions. This custom logic doesn't support the method signature with the URL object, so I'm updating this request to use the non-polluted method instead.

**issue:** https://github.com/articulate/identity/issues/1093