### PR TITLE
Use standard `https.request` signature

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,8 +3,10 @@
 .DS_Store
 .eslintrc.js
 .gitignore
+.nyc_output
 .travis.yml
-/.nyc_output
-/node_modules
-/test
+CODEOWNERS
+coverage
+node_modules
+test
 yarn.lock

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,12 +1,20 @@
 const http = require('http')
 const https = require('https')
 
+const getHttpRequestOptions = ({ url, timeout }) => ({
+  method: 'GET',
+  protocol: url.protocol,
+  hostname: url.hostname,
+  path: url.pathname,
+  timeout,
+})
+
 const getRequest = (url, timeout = 30 * 1000) =>
   new Promise((resolve, reject) => {
     const urlObject = new URL(url)
-    const httpRequestLib = urlObject.protocol === 'https:' ? https : http
-    const httpOptions = { method: 'GET', timeout }
-    const httpRequest = httpRequestLib.request(urlObject, httpOptions, res => {
+    const httpClient = urlObject.protocol === 'https:' ? https : http
+    const httpRequestOptions = getHttpRequestOptions({ timeout, url: urlObject })
+    const httpRequest = httpClient.request(httpRequestOptions, res => {
       const rawData = []
 
       res.setEncoding('utf8')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/authentic",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Proper validation of JWT's against JWK's",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Follow up of https://github.com/articulate/authentic/pull/31

Using the old signature for [https.request](https://nodejs.org/api/https.html#httpsrequestoptions-callback) where the first parameter is an object with all the request settings, the libraries patching the global object don't support the new signature where the first parameter is an URL object.

I created a runkit to demonstrate how these changes should fix the existing problem: https://runkit.com/embed/cifav9xx2k8m