### PR TITLE
chore: disable lifecycle scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Run TS check
         run: npx tsc --noEmit
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,7 +1,9 @@
+import { createRequire } from 'node:module'
+
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 
-import packageJson from './package.json' assert { type: 'json' }
+const packageJson = createRequire(import.meta.url)('./package.json')
 
 const name = packageJson.main.replace(/\.js$/, '')
 


### PR DESCRIPTION
## Description
Disables lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`) from running
during package install to reduce supply chain attack surface.

Configured using the repo's existing package manager — no package manager migration required:
- **yarn** — adds `enableScripts: false` to `.yarnrc.yml`
- **npm** — adds `ignore-scripts=true` to `.npmrc`

Repos already using pnpm are skipped (lifecycle scripts are blocked by default).

## References
- https://yarnpkg.com/configuration/yarnrc#enableScripts
- https://docs.npmjs.com/cli/v10/using-npm/config#ignore-scripts